### PR TITLE
Add option to exclude files if using rsync

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ The `API_TOKEN_GITHUB` needs to be set in the `Secrets` section of your reposito
 * destination_branch_create: [optional] A branch to be created with this commit, defaults to commiting in `destination_branch`
 * commit_message: [optional] A custom commit message for the commit. Defaults to `Update from https://github.com/${GITHUB_REPOSITORY}/commit/${GITHUB_SHA}`
 * use_rsync: [optional] Uses `rsync -avh` instead of `cp -R` to perform the base operation. Currently works as an experimental feature (due to lack of testing) but can speed up updates to large collections of files with many small changes by only syncing the changes and not copying the entire contents again. Please understand your use case before using this, and provide feedback as issues if needed.
+* exclude_file: [optional] Files to exclude if using rsync. Currently works as an experimental feature (due to lack of testing). Please understand your use case before using this, and provide feedback as issues if needed.
+
 
 # Behavior Notes
 The action will create any destination paths if they don't exist. It will also overwrite existing files if they already exist in the locations being copied to. It will not delete the entire destination repository.

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The `API_TOKEN_GITHUB` needs to be set in the `Secrets` section of your reposito
 * destination_branch_create: [optional] A branch to be created with this commit, defaults to commiting in `destination_branch`
 * commit_message: [optional] A custom commit message for the commit. Defaults to `Update from https://github.com/${GITHUB_REPOSITORY}/commit/${GITHUB_SHA}`
 * use_rsync: [optional] Uses `rsync -avh` instead of `cp -R` to perform the base operation. Currently works as an experimental feature (due to lack of testing) but can speed up updates to large collections of files with many small changes by only syncing the changes and not copying the entire contents again. Please understand your use case before using this, and provide feedback as issues if needed.
-* exclude_file: [optional] Files to exclude if using rsync. Currently works as an experimental feature (due to lack of testing). Please understand your use case before using this, and provide feedback as issues if needed.
+* exclude_files: [optional] Files to exclude if using rsync. Currently works as an experimental feature (due to lack of testing). Please understand your use case before using this, and provide feedback as issues if needed.
 
 
 # Behavior Notes

--- a/action.yml
+++ b/action.yml
@@ -52,6 +52,7 @@ runs:
     - ${{ inputs.git-server }}
     - ${{ inputs.rename }}
     - ${{ inputs.use-rsync }}
+    - ${{ inputs.exclude-file }}
 branding:
   icon: 'git-commit'
   color: 'green'

--- a/action.yml
+++ b/action.yml
@@ -31,7 +31,7 @@ inputs:
   use_rsync:
     description: 'Copy files/directories using rsync instead of cp. Experimental feature, please know your use case'
     required: false
-  exclude_file:
+  exclude_files:
     description: 'Files to exclude if using rsync. Uses the same syntax as the rsync command.'
     required: false
   git_server:
@@ -52,7 +52,7 @@ runs:
     - ${{ inputs.git-server }}
     - ${{ inputs.rename }}
     - ${{ inputs.use-rsync }}
-    - ${{ inputs.exclude-file }}
+    - ${{ inputs.exclude-files }}
 branding:
   icon: 'git-commit'
   color: 'green'

--- a/action.yml
+++ b/action.yml
@@ -31,6 +31,9 @@ inputs:
   use_rsync:
     description: 'Copy files/directories using rsync instead of cp. Experimental feature, please know your use case'
     required: false
+  exclude_file:
+    description: 'Files to exclude if using rsync. Uses the same syntax as the rsync command.'
+    required: false
   git_server:
     description: 'Git server host, default github.com'
     required: false

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -42,7 +42,11 @@ then
   cp -R "$INPUT_SOURCE_FILE" "$DEST_COPY"
 else
   echo "rsync mode detected"
-  rsync -avrh "$INPUT_SOURCE_FILE" "$DEST_COPY"
+  if [ -z "$INPUT_EXCLUDE_FILES" ]
+    rsync -avrh --exclue "$INPUT_EXCLUDE_FILES" "$INPUT_SOURCE_FILE" "$DEST_COPY"
+  else
+    rsync -avrh "$INPUT_SOURCE_FILE" "$DEST_COPY"
+  fi
 fi
 
 cd "$CLONE_DIR"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -43,7 +43,7 @@ then
 else
   echo "rsync mode detected"
   if [ -z "$INPUT_EXCLUDE_FILES" ]
-    rsync -avrh --exclue "$INPUT_EXCLUDE_FILES" "$INPUT_SOURCE_FILE" "$DEST_COPY"
+    rsync -avrh --exclude "$INPUT_EXCLUDE_FILES" "$INPUT_SOURCE_FILE" "$DEST_COPY"
   else
     rsync -avrh "$INPUT_SOURCE_FILE" "$DEST_COPY"
   fi


### PR DESCRIPTION
The same PR as https://github.com/dmnemec/copy_file_to_another_repo_action/pull/66

Add option to use rsyncs exclude parameter to do just that as requested in https://github.com/dmnemec/copy_file_to_another_repo_action/issues/26